### PR TITLE
Fix metadata parsing error

### DIFF
--- a/src/Horarium/Handlers/RunnerJobs.cs
+++ b/src/Horarium/Handlers/RunnerJobs.cs
@@ -96,12 +96,11 @@ namespace Horarium.Handlers
                 _horariumLogger.Error("Ошибка получения джоба из базы", ex);
             }
 
+            if (job == null) return null;
+
             try
             {
-                if (job != null)
-                {
-                    return job.ToJob(_jsonSerializerSettings);
-                }
+                return job.ToJob(_jsonSerializerSettings);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
If metadate cannot be parsed (because of type of the job or parameters is absent in assembly) the job will try to start constantly without using a retrying strategy. I suggest setting the job as failed to restart it later manually.